### PR TITLE
Fix github oauth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hickford/git-credential-oauth
 
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/main.go
+++ b/main.go
@@ -15,15 +15,10 @@ package main
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/hickford/git-credential-oauth/internal/devops"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/authhandler"
-	"golang.org/x/oauth2/endpoints"
 	"io"
 	"log"
 	"math/rand"
@@ -35,6 +30,11 @@ import (
 	"runtime"
 	"runtime/debug"
 	"strings"
+
+	"github.com/hickford/git-credential-oauth/internal/devops"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/authhandler"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // configByHost lists default config for several public hosts.
@@ -497,12 +497,9 @@ func replaceHost(e oauth2.Endpoint, host string) oauth2.Endpoint {
 }
 
 func generatePKCEParams() *authhandler.PKCEParams {
-	verifier := randomString(32)
-	sha := sha256.Sum256([]byte(verifier))
-	challenge := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(sha[:])
-
+	verifier := oauth2.GenerateVerifier()
 	return &authhandler.PKCEParams{
-		Challenge:       challenge,
+		Challenge:       oauth2.S256ChallengeFromVerifier(verifier),
 		ChallengeMethod: "S256",
 		Verifier:        verifier,
 	}


### PR DESCRIPTION
The previous way to generate the PKCE Params
resulted in failures with github.
The result is a nasty:
oauth2: "bad_verification_code" "The code passed is incorrect or expired."

Using oauth2 to generate a verifier and the challenge results in correct params being generated